### PR TITLE
L10-1: Solution, project, and dev environment scaffolding

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Enforced by TI Engineering Standards: .NET formatting must pass before commit.
+set -e
+
+echo "Running 'dotnet format --verify-no-changes' on TheL10inator.sln ..."
+dotnet format TheL10inator.sln --verify-no-changes --no-restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  backend:
+    name: Backend (build + unit tests)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore TheL10inator.sln
+
+      - name: Build
+        run: dotnet build TheL10inator.sln -c Release --no-restore
+
+      - name: Test - Domain
+        run: dotnet test tests/TheL10inator.Domain.Tests -c Release --no-build --no-restore
+
+      - name: Test - Api
+        run: dotnet test tests/TheL10inator.Api.Tests -c Release --no-build --no-restore
+
+  frontend:
+    name: Frontend (build)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: src/TheL10inator.Web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --prefix src/TheL10inator.Web
+
+      - name: Build
+        run: npm run build --prefix src/TheL10inator.Web

--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@ Internal web app for running One Click Contractor's weekly EOS Level 10 (L10) le
 
 Built by Theoretically Impossible for OCC as a deliberate exercise of the TI v4 agentic development pipeline.
 
-See [`docs/PRD.md`](docs/PRD.md), [`docs/screen-inventory.md`](docs/screen-inventory.md), and [`docs/decisions-log.md`](docs/decisions-log.md) for the full design story.
+## Documentation
+
+- [`CLAUDE.md`](CLAUDE.md) — project-specific rules and conventions
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — system design, database schema, design rationale
+- [`docs/PRD.md`](docs/PRD.md) — product requirements
+- [`docs/screen-inventory.md`](docs/screen-inventory.md) — screen inventory
+- [`docs/decisions-log.md`](docs/decisions-log.md) — PRD-phase decisions log
+- **Project board:** https://github.com/users/drdatarulz/projects/11 — single source of truth for work tracking
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -13,3 +13,13 @@ Running log of milestones reached and noteworthy build events. `orchestrate-v4` 
 - Baseline: `dotnet build` clean (0 warn / 0 err), smoke test passes, `ng build` clean.
 - Standards synced from `../TI-Engineering-Standards/`; skills copied into `.claude/skills/`; commit-msg hook installed via `.githooks/`.
 - Backlog generation (Phase 3.3) not yet run.
+
+## 2026-04-21 — L10-1 scaffolding completion
+
+- Seed DbUp migration `src/TheL10inator.Migrator/Scripts/001_Initial.sql` added (comment-only; tables land with feature stories).
+- Api wired per `standards/logging.md`: `AspNetCore.HealthChecks.SqlServer` DI, `MapHealthChecks("/health/live" | "/health/ready")`, `CompactJsonFormatter` for non-Development, plain console in Development, `CorrelationIdMiddleware` pushes `X-Correlation-Id` into `LogContext` and echoes it on the response.
+- `src/TheL10inator.Web/nginx.conf` extended with a `/health/` reverse-proxy block; `docker-compose.yml` web port mapping changed to `80:80`.
+- CI workflow `.github/workflows/ci.yml` added with parallel `backend` (build + unit tests) and `frontend` (npm ci + build) jobs.
+- Pre-commit hook (`.githooks/pre-commit`) runs `dotnet format TheL10inator.sln --verify-no-changes --no-restore`.
+- README updated with links to `ARCHITECTURE.md` and project board (`https://github.com/users/drdatarulz/projects/11`).
+- Smoke verified locally: `curl /health/live` → 200 "Healthy", `/health/ready` → 503 without SQL, correlation id auto-generated when absent and echoed when supplied.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     environment:
       API_UPSTREAM: "http://api:8080"
     ports:
-      - "4300:80"
+      - "80:80"
 
 volumes:
   sql_data:

--- a/src/TheL10inator.Api/Middleware/CorrelationIdMiddleware.cs
+++ b/src/TheL10inator.Api/Middleware/CorrelationIdMiddleware.cs
@@ -1,0 +1,41 @@
+using Serilog.Context;
+
+namespace TheL10inator.Api.Middleware;
+
+/// <summary>
+/// Reads the <c>X-Correlation-Id</c> request header (generating a new GUID when absent),
+/// pushes it into Serilog's <see cref="LogContext"/> as <c>CorrelationId</c>, and echoes
+/// the value back on the response header so clients can trace requests end-to-end.
+/// Registered before <c>UseSerilogRequestLogging()</c> so the correlation id appears on
+/// the request completion log entry.
+/// </summary>
+public sealed class CorrelationIdMiddleware
+{
+    private const string HeaderName = "X-Correlation-Id";
+
+    private readonly RequestDelegate _next;
+
+    public CorrelationIdMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var correlationId = context.Request.Headers.TryGetValue(HeaderName, out var existing)
+            && !string.IsNullOrWhiteSpace(existing)
+                ? existing.ToString()
+                : Guid.NewGuid().ToString();
+
+        context.Response.OnStarting(() =>
+        {
+            context.Response.Headers[HeaderName] = correlationId;
+            return Task.CompletedTask;
+        });
+
+        using (LogContext.PushProperty("CorrelationId", correlationId))
+        {
+            await _next(context);
+        }
+    }
+}

--- a/src/TheL10inator.Api/Program.cs
+++ b/src/TheL10inator.Api/Program.cs
@@ -1,17 +1,40 @@
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Serilog;
+using Serilog.Formatting.Compact;
+using TheL10inator.Api.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Host.UseSerilog((context, services, configuration) => configuration
-    .ReadFrom.Configuration(context.Configuration)
-    .ReadFrom.Services(services)
-    .Enrich.FromLogContext()
-    .WriteTo.Console());
+builder.Host.UseSerilog((context, services, configuration) =>
+{
+    configuration
+        .ReadFrom.Configuration(context.Configuration)
+        .ReadFrom.Services(services)
+        .Enrich.FromLogContext();
+
+    if (context.HostingEnvironment.IsDevelopment())
+    {
+        configuration.WriteTo.Console();
+    }
+    else
+    {
+        configuration.WriteTo.Console(new CompactJsonFormatter());
+    }
+});
 
 builder.Services.AddOpenApi();
 
+var connectionString = builder.Configuration.GetConnectionString("Sql") ?? string.Empty;
+
+var healthChecks = builder.Services.AddHealthChecks();
+if (!string.IsNullOrWhiteSpace(connectionString))
+{
+    healthChecks.AddSqlServer(connectionString, name: "database");
+}
+
 var app = builder.Build();
 
+app.UseMiddleware<CorrelationIdMiddleware>();
 app.UseSerilogRequestLogging();
 
 if (app.Environment.IsDevelopment())
@@ -19,8 +42,11 @@ if (app.Environment.IsDevelopment())
     app.MapOpenApi();
 }
 
-app.MapGet("/health/live", () => Results.Ok(new { status = "live" }));
-app.MapGet("/health/ready", () => Results.Ok(new { status = "ready" }));
+app.MapHealthChecks("/health/live", new HealthCheckOptions
+{
+    Predicate = _ => false,
+});
+app.MapHealthChecks("/health/ready");
 
 app.Run();
 

--- a/src/TheL10inator.Api/TheL10inator.Api.csproj
+++ b/src/TheL10inator.Api/TheL10inator.Api.csproj
@@ -6,9 +6,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.8.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>
 

--- a/src/TheL10inator.Api/appsettings.json
+++ b/src/TheL10inator.Api/appsettings.json
@@ -1,5 +1,6 @@
 {
   "Serilog": {
+    "Using": [ "Serilog.Sinks.Console" ],
     "MinimumLevel": {
       "Default": "Information",
       "Override": {

--- a/src/TheL10inator.Migrator/Scripts/001_Initial.sql
+++ b/src/TheL10inator.Migrator/Scripts/001_Initial.sql
@@ -1,0 +1,1 @@
+-- TheL10inator initial migration. Tables land with feature stories.

--- a/src/TheL10inator.Web/nginx.conf
+++ b/src/TheL10inator.Web/nginx.conf
@@ -27,6 +27,12 @@ server {
         proxy_read_timeout 86400;
     }
 
+    location /health/ {
+        proxy_pass ${API_UPSTREAM};
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
     # SPA fallback
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Summary

- Closes the remaining gaps from the initial scaffold (commit 828c05d) against L10-1's acceptance criteria: seed migration, structured logging, health checks, correlation middleware, nginx `/health/` proxy, port remap, CI workflow, pre-commit hook, and README links.
- Api now boots with portable `CompactJsonFormatter` JSON logs (non-Dev), plain console (Dev), `X-Correlation-Id` auto-gen and echo, and `/health/live` + `/health/ready` served via `MapHealthChecks` with `AddSqlServer`.
- Local smoke verified: `curl /health/live` returns 200 "Healthy" with `X-Correlation-Id` set; `/health/ready` returns 503 when SQL unreachable (correct behaviour before `docker compose up`).

## Changes

| File | Change |
|------|--------|
| `src/TheL10inator.Migrator/Scripts/001_Initial.sql` | New comment-only seed migration (embedded resource); removed `.gitkeep`. |
| `src/TheL10inator.Api/TheL10inator.Api.csproj` | Added `AspNetCore.HealthChecks.SqlServer`, `Serilog.Formatting.Compact`, `Serilog.Sinks.Console`. |
| `src/TheL10inator.Api/Program.cs` | Rewritten — conditional compact JSON sink, correlation middleware registration, `MapHealthChecks` with SQL dependency. |
| `src/TheL10inator.Api/Middleware/CorrelationIdMiddleware.cs` | New — reads/generates `X-Correlation-Id`, pushes to `LogContext`, echoes on response. |
| `src/TheL10inator.Api/appsettings.json` | Added `Serilog.Using: ["Serilog.Sinks.Console"]`. |
| `src/TheL10inator.Web/nginx.conf` | Added `/health/` reverse-proxy block. |
| `docker-compose.yml` | `web` port mapping `4300:80` → `80:80`. |
| `.github/workflows/ci.yml` | New — parallel `backend` (unit tests only) + `frontend` (`npm ci` + `npm run build`) jobs on PR/push to `main`. |
| `.githooks/pre-commit` | New — `dotnet format TheL10inator.sln --verify-no-changes --no-restore`. |
| `README.md` | Added ARCHITECTURE.md and project board links; full doc artifact list. |
| `STATUS.md` | Appended 2026-04-21 L10-1 completion entry. |

## Decisions

- **Compact JSON gated on `IsDevelopment()`** per CLAUDE.md's "no Azure-specific coupling" rule; overrides ARCHITECTURE.md's "App Insights or equivalent" wording in favor of portable stdout JSON.
- **Health checks via `MapHealthChecks` + `AspNetCore.HealthChecks.SqlServer`**, matching `standards/logging.md` §Health Checks verbatim. Connection-string-less fallback skips the SQL check registration (defensive; lets the Api start even if config isn't wired yet).
- **CI intentionally defers Integration + Playwright tiers** — the spec allows this until the first M1 vertical slice arrives with real tests.
- **`Serilog.Sinks.Console` explicit reference** — already transitive through `Serilog.AspNetCore`, but explicit keeps the sink contract visible in the csproj (per issue's Risks section).

## Test Coverage

- New tests: 0 (no domain logic in this story; `SmokeTests.Solution_Builds_And_Tests_Discover` continues to pass).
- All unit tests pass: yes (Domain.Tests 1/1, Api.Tests has no tests yet — compiles clean).
- Full solution builds: yes (`dotnet build TheL10inator.sln` → 0 warnings, 0 errors in both Debug and Release).
- Frontend build: yes (`npm ci && npm run build` in `src/TheL10inator.Web` is clean).
- `dotnet format --verify-no-changes` is clean.
- Manual smoke: `/health/live` → 200 "Healthy"; `/health/ready` → 503 without SQL; `X-Correlation-Id` auto-generated when absent, echoed when supplied.

Closes #1